### PR TITLE
Count Dr. Pepper Correctly

### DIFF
--- a/TwoLiterStack/.classpath
+++ b/TwoLiterStack/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/TwoLiterStack/src/main/TwoLiter.java
+++ b/TwoLiterStack/src/main/TwoLiter.java
@@ -47,8 +47,8 @@ public class TwoLiter {
 //		Random r = new Random(42);
 		Random r = new Random();
 		for (int i = 0; i < count; i++) {
-			twoLiterStack.add(new TwoLiter(UPCs[r.nextInt(UPCs.length - 1)], 
-					                       flavors[r.nextInt(flavors.length - 1)], 
+			twoLiterStack.add(new TwoLiter(UPCs[r.nextInt(UPCs.length)], 
+					                       flavors[r.nextInt(flavors.length)], 
 					                       1.00 + r.nextFloat()));
 		}
 	}


### PR DESCRIPTION
Inside the add method in the TwoLiter.java class, there were two "-1"s, one after "UPCs.length" and the other after "flavors.length". These needed to be omited in order for the program to run as intended and count the amount of Dr. Pepper in the stack.