### PR TITLE
TwoLiter: Correct int randomization on add method

### DIFF
--- a/TwoLiterStack/src/main/TwoLiter.java
+++ b/TwoLiterStack/src/main/TwoLiter.java
@@ -47,8 +47,8 @@ public class TwoLiter {
 //		Random r = new Random(42);
 		Random r = new Random();
 		for (int i = 0; i < count; i++) {
-			twoLiterStack.add(new TwoLiter(UPCs[r.nextInt(UPCs.length - 1)], 
-					                       flavors[r.nextInt(flavors.length - 1)], 
+			twoLiterStack.add(new TwoLiter(UPCs[r.nextInt(UPCs.length)], 
+					                       flavors[r.nextInt(flavors.length)], 
 					                       1.00 + r.nextFloat()));
 		}
 	}


### PR DESCRIPTION
In the two liter method add, the randomized nextInt() was always in the bounds of UPCs.length/flavors.length minus 1. In doing this, the UPC["00078000082463"], flavors["Dr. Pepper"] would never be called. In removing the minus 1, these two values are accessed, allowing us to have an both an accurate total price and a working Dr. Pepper count.